### PR TITLE
Update README setup commands to remove nightly rust and cargo-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Quickstart:
 
 git clone https://github.com/rustyscreeps/screeps-starter-rust.git
 cd screeps-starter-rust
-rustup override set nightly
 
 # cli dependencies:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ cd screeps-starter-rust
 # cli dependencies:
 
 cargo install cargo-screeps
-cargo install cargo-web
 
 # configure for uploading:
 


### PR DESCRIPTION
Neither of these should be required today - which is nice!