### PR TITLE
Update for compatibility with version 0.7.0 of screeps-game-api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 stdweb = "0.4"
 log = "0.4"
 fern = "0.5"
-screeps-game-api = "0.6"
+screeps-game-api = "0.7"
 
 [profile.release]
 panic = "abort"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use log::*;
-use screeps::{find, prelude::*, Part, ReturnCode, RoomObjectProperties};
+use screeps::{find, prelude::*, Part, ResourceType, ReturnCode, RoomObjectProperties};
 use stdweb::js;
 
 mod logging;
@@ -69,11 +69,11 @@ fn game_loop() {
         }
 
         if creep.memory().bool("harvesting") {
-            if creep.carry_total() == creep.carry_capacity() {
+            if creep.store_free_capacity(Some(ResourceType::Energy)) == 0 {
                 creep.memory().set("harvesting", false);
             }
         } else {
-            if creep.carry_total() == 0 {
+            if creep.store_used_capacity(None) == 0 {
                 creep.memory().set("harvesting", true);
             }
         }


### PR DESCRIPTION
Switch from `carry` to `store` properties for compatibility with the updated API.

Fixes the latest issues reported in #15