### PR TITLE
Update to upstream library version 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 stdweb = "0.4"
 log = "0.4"
 fern = "0.6"
-screeps-game-api = "0.8"
+screeps-game-api = "0.9"
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
Update to current release; works as-is for 0.9, none of the breaking changes impacted the minimal code.