### PR TITLE
Fixed build Errors on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,10 @@ opt-level = 3
 lto = true
 
 [package.metadata.wasm-pack.profile.release]
-# Replace the following with `wasm-opt = ["-O4"]` if improved performance is required. Will require additional dependencies
+# Replace the following with `wasm-opt = ["-O4", "-g"]` if improved performance is required. 
+# Removing the `"-g"` will further decrease the size of the wasm at the cost of renaming functions making debugging harder
+# Will require additional dependencies
+
 wasm-opt = false
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ lto = true
 # Replace the following with `wasm-opt = ["-O4", "-g"]` if improved performance is required. 
 # Removing the `"-g"` will further decrease the size of the wasm at the cost of renaming functions making debugging harder
 # Will require additional dependencies
-
 wasm-opt = false
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ opt-level = 3
 lto = true
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O4"]
+# Replace the following with `wasm-opt = ["-O4"]` if improved performance is required. Will require additional dependencies
+wasm-opt = false
 
 [features]
 default = ["console_error_panic_hook"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,13 +126,13 @@ fn run_creep(creep: &Creep, creep_targets: &mut HashMap<String, CreepTarget>) {
             // no target, let's find one depending on if we have energy
             let room = creep.room().expect("couldn't resolve creep room");
             if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 {
-                for structure in room.find(find::STRUCTURES).iter() {
+                for structure in room.find(find::STRUCTURES, None).iter() {
                     if let StructureObject::StructureController(controller) = structure {
                         entry.insert(CreepTarget::Upgrade(controller.id()));
                         break;
                     }
                 }
-            } else if let Some(source) = room.find(find::SOURCES_ACTIVE).get(0) {
+            } else if let Some(source) = room.find(find::SOURCES_ACTIVE, None).get(0) {
                 entry.insert(CreepTarget::Harvest(source.id()));
             }
         }


### PR DESCRIPTION
Disabled `wasm-opt` by default with a note to enable it if additional performance is required and fixed `.find` calls to provide None for the Options. 