### PR TITLE
Add example of getting random values, use them for creep name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+fern = "0.6"
+getrandom = { version = "0.2", features = ["custom"] }
 js-sys = "0.3"
 log = "0.4"
-fern = "0.6"
+rand = "0.8"
 screeps-game-api = "0.10"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd screeps-starter-rust
 cp example-screeps.toml screeps.toml
 nano screeps.toml
 # configure credentials (API key) if you'd like to upload directly,
-# or a directory to copy to if you'd prepfer to use the game client to deploy
+# or a directory to copy to if you'd prefer to use the game client to deploy
 
 # build tool:
 cargo screeps --help


### PR DESCRIPTION
I finally bothered to get a proof of concept going of getting randomness the 'right' way within Screeps WASM - it's a little tricky since the `js` feature on the getrandom crate assumes we have interfaces we don't, so going down that path is a trap, and we need a custom randomness function.

This replaces the `additional` part of the creep name with a random value instead of an incrementor - arguably this makes the example bot worse since it risks failing to spawn a creep when it could before , but also it's...

 1. a common enough feature that people want in their bots,
 2. extremely low risk of actually causing issues since people aren't likely multi-rooming on the example bot unmodified, and
 3. a bit wordy to document the setup for since you're adding two crate dependencies (but one is only to turn on a feature) then calling a macro on the function with the right signature to register

 ..so it seems like having this as part of the example would be an overall good/not too much extra complexity.