### PR TITLE
Update for crate version 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,6 @@
 ###################
 target
 
-# Build Files #
-###############
-Cargo.lock
-
 # Packages #
 ############
 *.7z

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 js-sys = "0.3"
 log = "0.4"
 fern = "0.6"
-screeps-game-api = "0.12"
+screeps-game-api = "0.13"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 
@@ -24,14 +24,17 @@ opt-level = 3
 lto = true
 
 [package.metadata.wasm-pack.profile.release]
-# Replace the following with `wasm-opt = ["-O4", "-g"]` (or with whatever flag
-# combo you'd like) to enable wasm-opt optimization, which wasm-pack will try to install
-# automatically, but must be installed separately on some operating systems
-# With newer rust versions, you might need to also add "--disable-sign-ext" in order to avoid the
-# usage of new opcodes which the screeps servers don't understand
-# Removing the `"-g"` will further decrease the size of the binary at but removes function names,
-# making stack traces upon panic less useful
+# Replace the following to enable wasm-opt optimization
+# wasm-pack will try to install wasm-opt automatically, but it must be installed by hand on some
+# operating systems.
 wasm-opt = false
+# See wasm-opt for full available options; handy examples:
+# -O4 - optimize aggressively for performance
+# -Oz - optimize aggressively for code size
+# -g - leave debug info in place, allowing for more descriptive stack traces on panic
+# --disable-sign-ext - prevents opcodes that the screeps servers can't load (see 
+# https://github.com/rustyscreeps/screeps-game-api/issues/391)
+#wasm-opt = ["-O4", "--disable-sign-ext"]
 
 [features]
 default = []

--- a/example-screeps.toml
+++ b/example-screeps.toml
@@ -1,5 +1,11 @@
 default_deploy_mode = "upload"
 
+[build]
+# options to allow building code against rust versions >=1.70 without opcodes
+# incompatible with screeps server environments; requires nightly rust. See 
+# https://github.com/rustyscreeps/screeps-game-api/issues/391
+extra_options = ["--config", "build.rustflags=['-Ctarget-cpu=mvp']", "-Z", "build-std=std,panic_abort", "-Z", "build-std-features=panic_immediate_abort"]
+
 [upload]
 auth_token = "your screeps.com auth token"
 
@@ -14,7 +20,7 @@ destination = "path to your local code directory from your game client, without 
 auth_token = "your screeps.com auth token"
 prefix = "season"
   [season.build]
-  extra_options = ["--features=my-crate-season-1-feature"]
+  extra_options = ["--features=my-crate-season-1-feature", "--config", "build.rustflags=['-Ctarget-cpu=mvp']", "-Z", "build-std=std,panic_abort", "-Z", "build-std-features=panic_immediate_abort"]
 
 # for full syntax and available options, see
 # https://github.com/rustyscreeps/screeps-game-api/blob/master/screeps-defaults.toml


### PR DESCRIPTION
- Update to crate version 0.13
- Clean up comments on wasm-opt options
- Add workaround for sign-ext disable to example `screeps.toml`
- Clean up imports of screeps-game-api types
- Remove outdated comments