### PR TITLE
Update for API crate version 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ crate-type = ["cdylib", "rlib"]
 js-sys = "0.3"
 log = "0.4"
 fern = "0.6"
-screeps-game-api = "0.15"
+screeps-game-api = "0.16"
+# If you'd like to use a locally-cloned out version of the game API crate
+# (for testing PRs, etc), you can use a local path (replacing the above line):
+#screeps-game-api = { path = "../screeps-game-api" }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 


### PR DESCRIPTION
Updated for 0.16, no code changes needed. Also added a comment with how to use a local version of the API crate.