### PR TITLE
Add console.error function for wasm_bindgen

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -4,9 +4,24 @@ let wasm_module;
 // replace this with the name of your module
 const MODULE_NAME = "screeps-starter-rust";
 
-function console_error(...args) {
-    console.log(...args);
-    Game.notify(args.join(' '));
+// This provides the function `console.error` that wasm_bindgen sometimes expects to exist,
+// especially with type checks in debug mode. An alternative is to have this be `function () {}`
+// and let the exception handler log the thrown JS exceptions, but there is some additional
+// information that wasm_bindgen only passes here.
+//
+// There is nothing special about this function and it may also be used by any JS/Rust code as a convenience.
+console.error = function () {
+    const processedArgs = _.map(arguments, (arg) => {
+        if (arg instanceof Error) {
+            // On this version of Node, the `stack` property of errors contains
+            // the message as well.
+            return arg.stack;
+        } else {
+            return arg;
+        }
+    }).join(' ');
+    console.log("ERROR:", processedArgs);
+    Game.notify(processedArgs);
 }
 
 module.exports.loop = function () {
@@ -34,14 +49,14 @@ module.exports.loop = function () {
             wasm_module.loop();
         }
     } catch (error) {
-        console_error("caught exception:", error);
+        console.error("caught exception:", error);
         // we've already logged the more-descriptive stack trace from rust's panic_hook
         // if for some reason (like wasm init problems) you're not getting output from that
         // and need more information, uncomment the following:
         // if (error.stack) {
-        //     console_error("stack trace:", error.stack);
+        //     console.error("stack trace:", error.stack);
         // }
-        console_error("resetting VM next tick.");
+        console.error("resetting VM next tick.");
         wasm_module = null;
     }
 }


### PR DESCRIPTION
When in debug mode, `wasm-bindgen` expects to be able to throw exceptions when it does certain checks.  Its error handler does approximately
```js
console.error("JS function threw an exception, but was not marked with catch", error);
throw error;
```
The screeps environment doesn't expose the web's version of `console` at all to the user, only a mock object in `global` that only has `log`.  This results in wasm bindgen's error handler instead throwing an exception `could not find function console.error` which is even more useless.

This PR adds that `error` function to the global `console` so that wasm bindgen can use it.  The current implementation has some drawbacks:

### Option 1: Implement a proper `console.error` with logging and `Game.notify`. (this PR)

#### Benefits:
- Adds more context to the errors, which is helpful in debug mode.
- Allows the errors to be automatically sent to the user.
- Function can be reused for general purpose.

#### Drawbacks:
- If the user has a top-level exception handler in JS (which they should, and this template provides), that exception handler will *also* print the (less useful) exception and possibly also call `Game.notify`.
  - This is at worst just visual clutter, no technical problems.
  

### Option 2: Implement `console.error` as `function () {}`.

#### Benefits:
- Avoids double logging and double notifying on wasm bindgen errors.
  - Less visual clutter.

#### Drawbacks:
- Possibly confusing to beginners.
- Misses the information that "wasm_bindgen function threw an exception" which adds the context that the *bindings* are incorrect.

### Option 3: Implement `console.error` as deferring to `console.log`.

#### Benefits:
- Makes sure that the information is all logged.

#### Drawbacks:
- Still double logs.
- Doesn't allow for easy modification of how things are displayed.


Therefore I believe that it's better for the default code that we provide to users have an actual implementation, and users can disable the function if they do not find value in it.

Also I updated the error handler in the starter to use this function.  Users probably expect error handling to be somewhat consistent, at least across JS errors.

cc @BlueskyFr who was part of uncovering this issue by being the first one in ages to use debug mode in a specific state that can occur on MMO but uncommonly.